### PR TITLE
Further shell integration

### DIFF
--- a/asub
+++ b/asub
@@ -104,7 +104,7 @@ if (!defined($opts{k}) || $opts{k} < 1) { # prepare to run
 			++$pid;
 			$pids{"$pid"}[0] = $cmd;
 			system("$shell", "-c", $cmd);
-			$pids{"$pid"}[1] = $?;
+			$pids{"$pid"}[1] = $? >> 8;
 		}
 	} else { # in parallel
 		for my $cmd (@cmds) {
@@ -117,7 +117,7 @@ if (!defined($opts{k}) || $opts{k} < 1) { # prepare to run
 			}
 		}
 		while (($pid = wait()) >= 0) {
-			$pids{$pid}[1] = $?;
+			$pids{$pid}[1] = $? >> 8;
 		}
 	}
 	warn("[asub] --- END OF COMMAND STDERR ---\n");

--- a/asub
+++ b/asub
@@ -96,13 +96,14 @@ if (!defined($opts{k}) || $opts{k} < 1) { # prepare to run
 
 	# launch command lines
 	my ($pid, %pids);
+    my $shell = $ENV{'SHELL'} || '/bin/sh';
 	warn("[asub] --- BEGIN OF COMMAND STDERR ---\n");
 	if ($opts{G}) { # in serial
 		$pid = 0;
 		for my $cmd (@cmds) {
 			++$pid;
 			$pids{"$pid"}[0] = $cmd;
-			system($cmd);
+			system("$shell", "-c", $cmd);
 			$pids{"$pid"}[1] = $?;
 		}
 	} else { # in parallel
@@ -112,7 +113,7 @@ if (!defined($opts{k}) || $opts{k} < 1) { # prepare to run
 			} elsif ($pid != 0) { # this the parent process
 				$pids{$pid}[0] = $cmd;
 			} else { # this is the child process
-				exec $cmd;
+				exec "$shell", "-c", $cmd;
 			}
 		}
 		while (($pid = wait()) >= 0) {


### PR DESCRIPTION
## More Shells
Execute job processes with the environment `$SHELL` if available.

This allows job commands which utilise process substitution.

## Correct Return Values
Return the correct return value from job processes.

Perl's `$?` variable contains the return value of the `system` and `exec` commands. However, this is really the return value of the `wait()` command. - http://perldoc.perl.org/perlvar.html#Error-Variables

The doc says to bit-shift the return value by 8 to get the true return value of the sub-process.

e.g.
```
system('./foo.sh');
my $true_return_value = $? >> 8;
```

Without this, a sub-process returning `1` will cause the `$?` variable to contain `256`, which the shell calling the Perl process interprets as `256 % 256` which equals `0`, which is very misleading.

## Testing
Tested with:
 - GNU bash, version 4.2.46(1)-release (x86_64-redhat-linux-gnu)
 - OpenLava 3.2.0, Mar 14 2016
 - perl 5, version 24, subversion 0 (v5.24.0)