### PR TITLE
Use the current perl environment

### DIFF
--- a/asub
+++ b/asub
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 
 # Author: lh3
 


### PR DESCRIPTION
Use the current perl defined in the environment. This enables the use of perlbrewed perls.

Note the `-w` option is already taken care of by `use warnings;`.